### PR TITLE
Shared OS Behaviour

### DIFF
--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -1,9 +1,7 @@
 use ::pnet::datalink::Channel::Ethernet;
 use ::pnet::datalink::DataLinkReceiver;
 use ::pnet::datalink::{self, Config, NetworkInterface};
-use ::std::io::{self, stdin, Write};
-use ::termion::event::Event;
-use ::termion::input::TermRead;
+use ::std::io::{self, Write};
 
 use ::std::collections::HashMap;
 use ::std::net::IpAddr;
@@ -15,17 +13,8 @@ use signal_hook::iterator::Signals;
 use crate::network::{Connection, Protocol};
 use crate::OsInputOutput;
 
-struct KeyboardEvents;
+use crate::os::shared::{KeyboardEvents};
 
-impl Iterator for KeyboardEvents {
-    type Item = Event;
-    fn next(&mut self) -> Option<Event> {
-        match stdin().events().next() {
-            Some(Ok(ev)) => Some(ev),
-            _ => None,
-        }
-    }
-}
 
 fn get_datalink_channel(
     interface: &NetworkInterface,

--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -1,38 +1,18 @@
-use ::pnet::datalink::Channel::Ethernet;
-use ::pnet::datalink::DataLinkReceiver;
-use ::pnet::datalink::{self, Config, NetworkInterface};
-use ::std::io::{self, Write};
-
 use ::std::collections::HashMap;
-use ::std::net::IpAddr;
-use ::std::time;
 
 use ::procfs::FDTarget;
-use signal_hook::iterator::Signals;
 
 use crate::network::{Connection, Protocol};
 use crate::OsInputOutput;
 
-use crate::os::shared::{KeyboardEvents};
-
-
-fn get_datalink_channel(
-    interface: &NetworkInterface,
-) -> Result<Box<dyn DataLinkReceiver>, failure::Error> {
-    let mut config = Config::default();
-    config.read_timeout = Some(time::Duration::new(0, 1));
-    match datalink::channel(interface, config) {
-        Ok(Ethernet(_tx, rx)) => Ok(rx),
-        Ok(_) => failure::bail!("Unknown interface type"),
-        Err(e) => failure::bail!("Failed to listen to network interface: {}", e),
-    }
-}
-
-fn get_interface(interface_name: &str) -> Option<NetworkInterface> {
-    datalink::interfaces()
-        .into_iter()
-        .find(|iface| iface.name == interface_name)
-}
+use crate::os::shared::{
+    KeyboardEvents,
+    get_datalink_channel,
+    get_interface,
+    lookup_addr,
+    sigwinch,
+    create_write_to_stdout,
+};
 
 fn get_open_sockets() -> HashMap<Connection, String> {
     let mut open_sockets = HashMap::new();
@@ -74,37 +54,7 @@ fn get_open_sockets() -> HashMap<Connection, String> {
     open_sockets
 }
 
-fn lookup_addr(ip: &IpAddr) -> Option<String> {
-    ::dns_lookup::lookup_addr(ip).ok()
-}
 
-fn sigwinch() -> (Box<dyn Fn(Box<dyn Fn()>) + Send>, Box<dyn Fn() + Send>) {
-    let signals = Signals::new(&[signal_hook::SIGWINCH]).unwrap();
-    let on_winch = {
-        let signals = signals.clone();
-        move |cb: Box<dyn Fn()>| {
-            for signal in signals.forever() {
-                match signal {
-                    signal_hook::SIGWINCH => cb(),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-    let cleanup = move || {
-        signals.close();
-    };
-    (Box::new(on_winch), Box::new(cleanup))
-}
-
-pub fn create_write_to_stdout() -> Box<dyn FnMut(String) + Send> {
-    Box::new({
-        let mut stdout = io::stdout();
-        move |output: String| {
-            writeln!(stdout, "{}", output).unwrap();
-        }
-    })
-}
 
 pub fn get_input(interface_name: &str) -> Result<OsInputOutput, failure::Error> {
     let keyboard_events = Box::new(KeyboardEvents);

--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -1,20 +1,9 @@
 use ::std::collections::HashMap;
-
 use ::procfs::FDTarget;
 
 use crate::network::{Connection, Protocol};
-use crate::OsInputOutput;
 
-use crate::os::shared::{
-    KeyboardEvents,
-    get_datalink_channel,
-    get_interface,
-    lookup_addr,
-    sigwinch,
-    create_write_to_stdout,
-};
-
-fn get_open_sockets() -> HashMap<Connection, String> {
+pub(crate) fn get_open_sockets() -> HashMap<Connection, String> {
     let mut open_sockets = HashMap::new();
     let all_procs = procfs::all_processes();
 
@@ -52,31 +41,4 @@ fn get_open_sockets() -> HashMap<Connection, String> {
         };
     }
     open_sockets
-}
-
-
-
-pub fn get_input(interface_name: &str) -> Result<OsInputOutput, failure::Error> {
-    let keyboard_events = Box::new(KeyboardEvents);
-    let network_interface = match get_interface(interface_name) {
-        Some(interface) => interface,
-        None => {
-            failure::bail!("Cannot find interface {}", interface_name);
-        }
-    };
-    let network_frames = get_datalink_channel(&network_interface)?;
-    let lookup_addr = Box::new(lookup_addr);
-    let write_to_stdout = create_write_to_stdout();
-    let (on_winch, cleanup) = sigwinch();
-
-    Ok(OsInputOutput {
-        network_interface,
-        network_frames,
-        get_open_sockets,
-        keyboard_events,
-        lookup_addr,
-        on_winch,
-        cleanup,
-        write_to_stdout,
-    })
 }

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -16,17 +16,7 @@ use crate::OsInputOutput;
 use super::lsof_utils;
 use std::net::SocketAddr;
 
-struct KeyboardEvents;
-
-impl Iterator for KeyboardEvents {
-    type Item = Event;
-    fn next(&mut self) -> Option<Event> {
-        match stdin().events().next() {
-            Some(Ok(ev)) => Some(ev),
-            _ => None,
-        }
-    }
-}
+use crate::os::shared::KeyboardEvents;
 
 fn get_datalink_channel(
     interface: &NetworkInterface,

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,3 +1,5 @@
+pub mod shared;
+
 #[cfg(target_os = "linux")]
 mod linux;
 

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,16 +1,12 @@
-pub(self) mod shared;
-
 #[cfg(target_os = "linux")]
-mod linux;
-
-#[cfg(target_os = "linux")]
-pub use linux::*;
+pub (self) mod linux;
 
 #[cfg(target_os = "macos")]
-mod macos;
-
-#[cfg(target_os = "macos")]
-pub use macos::*;
+pub (self) mod macos;
 
 #[cfg(target_os = "macos")]
 mod lsof_utils;
+
+mod shared;
+
+pub use shared::*;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,4 +1,4 @@
-pub mod shared;
+pub(self) mod shared;
 
 #[cfg(target_os = "linux")]
 mod linux;

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -1,0 +1,15 @@
+use ::std::io::stdin;
+use ::termion::event::Event;
+use ::termion::input::TermRead;
+
+pub struct KeyboardEvents;
+
+impl Iterator for KeyboardEvents {
+    type Item = Event;
+    fn next(&mut self) -> Option<Event> {
+        match stdin().events().next() {
+            Some(Ok(ev)) => Some(ev),
+            _ => None,
+        }
+    }
+}

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -28,7 +28,7 @@ impl Iterator for KeyboardEvents {
     }
 }
 
-pub fn get_datalink_channel(
+fn get_datalink_channel(
     interface: &NetworkInterface,
 ) -> Result<Box<dyn DataLinkReceiver>, failure::Error> {
     let mut config = Config::default();
@@ -40,17 +40,17 @@ pub fn get_datalink_channel(
     }
 }
 
-pub fn get_interface(interface_name: &str) -> Option<NetworkInterface> {
+fn get_interface(interface_name: &str) -> Option<NetworkInterface> {
     datalink::interfaces()
         .into_iter()
         .find(|iface| iface.name == interface_name)
 }
 
-pub fn lookup_addr(ip: &IpAddr) -> Option<String> {
+fn lookup_addr(ip: &IpAddr) -> Option<String> {
     ::dns_lookup::lookup_addr(ip).ok()
 }
 
-pub fn sigwinch() -> (Box<dyn Fn(Box<dyn Fn()>) + Send>, Box<dyn Fn() + Send>) {
+fn sigwinch() -> (Box<dyn Fn(Box<dyn Fn()>) + Send>, Box<dyn Fn() + Send>) {
     let signals = Signals::new(&[signal_hook::SIGWINCH]).unwrap();
     let on_winch = {
         let signals = signals.clone();
@@ -69,7 +69,7 @@ pub fn sigwinch() -> (Box<dyn Fn(Box<dyn Fn()>) + Send>, Box<dyn Fn() + Send>) {
     (Box::new(on_winch), Box::new(cleanup))
 }
 
-pub fn create_write_to_stdout() -> Box<dyn FnMut(String) + Send> {
+fn create_write_to_stdout() -> Box<dyn FnMut(String) + Send> {
     Box::new({
         let mut stdout = io::stdout();
         move |output: String| {

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -1,4 +1,12 @@
-use ::std::io::stdin;
+use ::pnet::datalink::Channel::Ethernet;
+use ::pnet::datalink::DataLinkReceiver;
+use ::pnet::datalink::{self, Config, NetworkInterface};
+
+use ::std::net::IpAddr;
+use ::std::time;
+
+use signal_hook::iterator::Signals;
+use ::std::io::{self, stdin, Write};
 use ::termion::event::Event;
 use ::termion::input::TermRead;
 
@@ -12,4 +20,54 @@ impl Iterator for KeyboardEvents {
             _ => None,
         }
     }
+}
+
+pub fn get_datalink_channel(
+    interface: &NetworkInterface,
+) -> Result<Box<dyn DataLinkReceiver>, failure::Error> {
+    let mut config = Config::default();
+    config.read_timeout = Some(time::Duration::new(0, 1));
+    match datalink::channel(interface, config) {
+        Ok(Ethernet(_tx, rx)) => Ok(rx),
+        Ok(_) => failure::bail!("Unknown interface type"),
+        Err(e) => failure::bail!("Failed to listen to network interface: {}", e),
+    }
+}
+
+pub fn get_interface(interface_name: &str) -> Option<NetworkInterface> {
+    datalink::interfaces()
+        .into_iter()
+        .find(|iface| iface.name == interface_name)
+}
+
+pub fn lookup_addr(ip: &IpAddr) -> Option<String> {
+    ::dns_lookup::lookup_addr(ip).ok()
+}
+
+pub fn sigwinch() -> (Box<dyn Fn(Box<dyn Fn()>) + Send>, Box<dyn Fn() + Send>) {
+    let signals = Signals::new(&[signal_hook::SIGWINCH]).unwrap();
+    let on_winch = {
+        let signals = signals.clone();
+        move |cb: Box<dyn Fn()>| {
+            for signal in signals.forever() {
+                match signal {
+                    signal_hook::SIGWINCH => cb(),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    let cleanup = move || {
+        signals.close();
+    };
+    (Box::new(on_winch), Box::new(cleanup))
+}
+
+pub fn create_write_to_stdout() -> Box<dyn FnMut(String) + Send> {
+    Box::new({
+        let mut stdout = io::stdout();
+        move |output: String| {
+            writeln!(stdout, "{}", output).unwrap();
+        }
+    })
 }


### PR DESCRIPTION
Resolves: imsnif/what#17

Moved the following into os/shared.rs:
* KeyboardEvents
* get_datalink_channel
* get_interface
* lookup_addr
* sigwinch
* create_write_to_stdout
* get_input

Of note: get_interface had a slightly different implementation between os/linux.rs and os/macos.rs and they have been standardized in os/shared.rs. The only difference between the implementation was that os/linux.rs set the config.read_timeout. 

Additionally, I noticed that there's a RawConnection struct in os/macos.rs, that wasn't being used in the file.

Also, I only have a Linux machine, and so I was unable to test the MacOS stuff, so please ensure to do that. 
