### PR TITLE
Listen on all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Windows is not supported at the moment - if you'd like to contribute a windows p
 ### Usage
 ```
 USAGE:
-    what [FLAGS] --interface <interface>
+    what [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help          Prints help information
@@ -46,14 +46,14 @@ Note that since `what` sniffs network packets, it requires root privileges - so 
 ### raw_mode
 `what` also supports an easier-to-parse mode that can be piped or redirected to a file. For example, try:
 ```
-what -i eth0 --raw | grep firefox
+what --raw | grep firefox
 ```
 ### Contributing
 Contributions of any kind are very welcome. If you'd like a new feature (or found a bug), please open an issue or a PR.
 
 To set up your development environment:
 1. Clone the project
-2. `cargo run -- -i <network interface name>` (you can often find out the name with `ifconfig` or `iwconfig`). You might need root privileges to run this application, so be sure to use (for example) sudo.
+2. `cargo run`, or if you prefer `cargo run -- -i <network interface name>` (you can often find out the name with `ifconfig` or `iwconfig`). You might need root privileges to run this application, so be sure to use (for example) sudo.
     
 To run tests: `cargo test`
 

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -64,7 +64,7 @@ impl<'a> Table<'a> {
             .iter()
             .map(|(connection, connection_data)| {
                 vec![
-                    display_connection_string(&connection, &ip_to_host),
+                    display_connection_string(&connection, &ip_to_host, &connection_data.interface),
                     connection_data.process_name.to_string(),
                     display_upload_and_download(*connection_data),
                 ]

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -64,7 +64,11 @@ impl<'a> Table<'a> {
             .iter()
             .map(|(connection, connection_data)| {
                 vec![
-                    display_connection_string(&connection, &ip_to_host, &connection_data.interface),
+                    display_connection_string(
+                        &connection,
+                        &ip_to_host,
+                        &connection_data.interface_name,
+                    ),
                     connection_data.process_name.to_string(),
                     display_upload_and_download(*connection_data),
                 ]

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -56,7 +56,7 @@ where
                 display_connection_string(
                     connection,
                     ip_to_host,
-                    &connection_network_data.interface
+                    &connection_network_data.interface_name
                 ),
                 connection_network_data.total_bytes_uploaded,
                 connection_network_data.total_bytes_downloaded,

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -53,7 +53,11 @@ where
             write_to_stdout(format!(
                 "connection: <{}> {} up/down Bps: {}/{} process: \"{}\"",
                 timestamp,
-                display_connection_string(connection, ip_to_host),
+                display_connection_string(
+                    connection,
+                    ip_to_host,
+                    &connection_network_data.interface
+                ),
                 connection_network_data.total_bytes_uploaded,
                 connection_network_data.total_bytes_downloaded,
                 connection_network_data.process_name

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -20,7 +20,7 @@ pub struct ConnectionData {
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
     pub process_name: String,
-    pub interface: String,
+    pub interface_name: String,
 }
 
 impl Bandwidth for ConnectionData {
@@ -74,7 +74,7 @@ impl UIState {
                 connection_data.total_bytes_downloaded += connection_info.total_bytes_downloaded;
                 connection_data.total_bytes_uploaded += connection_info.total_bytes_uploaded;
                 connection_data.process_name = process_name;
-                connection_data.interface = connection_info.interface;
+                connection_data.interface_name = connection_info.interface_name;
                 data_for_remote_address.total_bytes_downloaded +=
                     connection_info.total_bytes_downloaded;
                 data_for_remote_address.total_bytes_uploaded +=

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -20,6 +20,7 @@ pub struct ConnectionData {
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
     pub process_name: String,
+    pub interface: String,
 }
 
 impl Bandwidth for ConnectionData {
@@ -52,7 +53,7 @@ pub struct UIState {
 impl UIState {
     pub fn new(
         connections_to_procs: HashMap<Connection, String>,
-        network_utilization: Utilization,
+        mut network_utilization: Utilization,
     ) -> Self {
         let mut processes: BTreeMap<String, NetworkData> = BTreeMap::new();
         let mut remote_addresses: BTreeMap<Ipv4Addr, NetworkData> = BTreeMap::new();
@@ -60,32 +61,27 @@ impl UIState {
         let mut total_bytes_downloaded: u128 = 0;
         let mut total_bytes_uploaded: u128 = 0;
         for (connection, process_name) in connections_to_procs {
-            if let Some(connection_bandwidth_utilization) =
-                network_utilization.connections.get(&connection)
-            {
+            if let Some(connection_info) = network_utilization.connections.remove(&connection) {
                 let data_for_remote_address = remote_addresses
                     .entry(connection.remote_socket.ip)
                     .or_default();
                 let connection_data = connections.entry(connection).or_default();
                 let data_for_process = processes.entry(process_name.clone()).or_default();
 
-                data_for_process.total_bytes_downloaded +=
-                    &connection_bandwidth_utilization.total_bytes_downloaded;
-                data_for_process.total_bytes_uploaded +=
-                    &connection_bandwidth_utilization.total_bytes_uploaded;
+                data_for_process.total_bytes_downloaded += connection_info.total_bytes_downloaded;
+                data_for_process.total_bytes_uploaded += connection_info.total_bytes_uploaded;
                 data_for_process.connection_count += 1;
-                connection_data.total_bytes_downloaded +=
-                    &connection_bandwidth_utilization.total_bytes_downloaded;
-                connection_data.total_bytes_uploaded +=
-                    &connection_bandwidth_utilization.total_bytes_uploaded;
+                connection_data.total_bytes_downloaded += connection_info.total_bytes_downloaded;
+                connection_data.total_bytes_uploaded += connection_info.total_bytes_uploaded;
                 connection_data.process_name = process_name;
+                connection_data.interface = connection_info.interface;
                 data_for_remote_address.total_bytes_downloaded +=
-                    connection_bandwidth_utilization.total_bytes_downloaded;
+                    connection_info.total_bytes_downloaded;
                 data_for_remote_address.total_bytes_uploaded +=
-                    connection_bandwidth_utilization.total_bytes_uploaded;
+                    connection_info.total_bytes_uploaded;
                 data_for_remote_address.connection_count += 1;
-                total_bytes_downloaded += connection_bandwidth_utilization.total_bytes_downloaded;
-                total_bytes_uploaded += connection_bandwidth_utilization.total_bytes_uploaded;
+                total_bytes_downloaded += connection_info.total_bytes_downloaded;
+                total_bytes_uploaded += connection_info.total_bytes_uploaded;
             }
         }
         UIState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,7 @@ where
                         network_utilization.lock().unwrap().update(segment);
                     }
                     if !running.load(Ordering::Acquire) {
+                        // Break from the outer loop and finish the thread
                         break 'sniffing;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use structopt::StructOpt;
 pub struct Opt {
     #[structopt(short, long)]
     /// The network interface to listen on, eg. eth0
-    interface: String,
+    interface: Option<String>,
     #[structopt(short, long)]
     /// Machine friendlier output
     raw: bool,
@@ -78,8 +78,8 @@ fn try_main() -> Result<(), failure::Error> {
 }
 
 pub struct OsInputOutput {
-    pub network_interface: NetworkInterface,
-    pub network_frames: Box<dyn DataLinkReceiver>,
+    pub network_interfaces: Vec<NetworkInterface>,
+    pub network_frames: Vec<Box<dyn DataLinkReceiver>>,
     pub get_open_sockets: fn() -> HashMap<Connection, String>,
     pub keyboard_events: Box<dyn Iterator<Item = Event> + Send>,
     pub dns_client: Option<dns::Client>,
@@ -105,7 +105,13 @@ where
 
     let raw_mode = opts.raw;
 
-    let mut sniffer = Sniffer::new(os_input.network_interface, os_input.network_frames);
+    let mut sniffers = os_input
+        .network_interfaces
+        .into_iter()
+        .zip(os_input.network_frames.into_iter())
+        .map(|(iface, frames)| Sniffer::new(iface, frames))
+        .collect::<Vec<Sniffer>>();
+
     let network_utilization = Arc::new(Mutex::new(Utilization::new()));
     let ui = Arc::new(Mutex::new(Ui::new(terminal_backend)));
 
@@ -196,10 +202,13 @@ where
     active_threads.push(
         thread::Builder::new()
             .name("sniffing_handler".to_string())
-            .spawn(move || {
-                while running.load(Ordering::Acquire) {
+            .spawn(move || 'sniffing: loop {
+                for sniffer in sniffers.iter_mut() {
                     if let Some(segment) = sniffer.next() {
-                        network_utilization.lock().unwrap().update(&segment)
+                        network_utilization.lock().unwrap().update(segment);
+                    }
+                    if !running.load(Ordering::Acquire) {
+                        break 'sniffing;
                     }
                 }
             })

--- a/src/network/connection.rs
+++ b/src/network/connection.rs
@@ -52,9 +52,11 @@ pub fn display_ip_or_host(ip: Ipv4Addr, ip_to_host: &HashMap<Ipv4Addr, String>) 
 pub fn display_connection_string(
     connection: &Connection,
     ip_to_host: &HashMap<Ipv4Addr, String>,
+    interface: &str,
 ) -> String {
     format!(
-        ":{} => {}:{} ({})",
+        "<{}>:{} => {}:{} ({})",
+        interface,
         connection.local_port,
         display_ip_or_host(connection.remote_socket.ip, ip_to_host),
         connection.remote_socket.port,

--- a/src/network/connection.rs
+++ b/src/network/connection.rs
@@ -52,11 +52,11 @@ pub fn display_ip_or_host(ip: Ipv4Addr, ip_to_host: &HashMap<Ipv4Addr, String>) 
 pub fn display_connection_string(
     connection: &Connection,
     ip_to_host: &HashMap<Ipv4Addr, String>,
-    interface: &str,
+    interface_name: &str,
 ) -> String {
     format!(
         "<{}>:{} => {}:{} ({})",
-        interface,
+        interface_name,
         connection.local_port,
         display_ip_or_host(connection.remote_socket.ip, ip_to_host),
         connection.remote_socket.port,

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -14,6 +14,7 @@ use ::std::net::{IpAddr, SocketAddr};
 use crate::network::{Connection, Protocol};
 
 pub struct Segment {
+    pub interface: String,
     pub connection: Connection,
     pub direction: Direction,
     pub data_length: u128,
@@ -81,6 +82,7 @@ impl Sniffer {
                         }
                         _ => return None,
                     };
+                let interface = self.network_interface.name.clone();
                 let direction = Direction::new(&self.network_interface.ips, &ip_packet);
                 let from = SocketAddr::new(IpAddr::V4(ip_packet.get_source()), source_port);
                 let to = SocketAddr::new(IpAddr::V4(ip_packet.get_destination()), destination_port);
@@ -90,6 +92,7 @@ impl Sniffer {
                     Direction::Upload => Connection::new(to, source_port, protocol)?,
                 };
                 Some(Segment {
+                    interface,
                     connection,
                     data_length,
                     direction,

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -14,7 +14,7 @@ use ::std::net::{IpAddr, SocketAddr};
 use crate::network::{Connection, Protocol};
 
 pub struct Segment {
-    pub interface: String,
+    pub interface_name: String,
     pub connection: Connection,
     pub direction: Direction,
     pub data_length: u128,
@@ -82,7 +82,7 @@ impl Sniffer {
                         }
                         _ => return None,
                     };
-                let interface = self.network_interface.name.clone();
+                let interface_name = self.network_interface.name.clone();
                 let direction = Direction::new(&self.network_interface.ips, &ip_packet);
                 let from = SocketAddr::new(IpAddr::V4(ip_packet.get_source()), source_port);
                 let to = SocketAddr::new(IpAddr::V4(ip_packet.get_destination()), destination_port);
@@ -92,7 +92,7 @@ impl Sniffer {
                     Direction::Upload => Connection::new(to, source_port, protocol)?,
                 };
                 Some(Segment {
-                    interface,
+                    interface_name,
                     connection,
                     data_length,
                     direction,

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -3,14 +3,15 @@ use crate::network::{Connection, Direction, Segment};
 use ::std::collections::HashMap;
 
 #[derive(Clone)]
-pub struct TotalBandwidth {
+pub struct ConnectionInfo {
+    pub interface: String,
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
 }
 
 #[derive(Clone)]
 pub struct Utilization {
-    pub connections: HashMap<Connection, TotalBandwidth>,
+    pub connections: HashMap<Connection, ConnectionInfo>,
 }
 
 impl Utilization {
@@ -23,14 +24,15 @@ impl Utilization {
         self.connections.clear();
         clone
     }
-    pub fn update(&mut self, seg: &Segment) {
-        let total_bandwidth =
-            self.connections
-                .entry(seg.connection.clone())
-                .or_insert(TotalBandwidth {
-                    total_bytes_downloaded: 0,
-                    total_bytes_uploaded: 0,
-                });
+    pub fn update(&mut self, seg: Segment) {
+        let total_bandwidth = self
+            .connections
+            .entry(seg.connection)
+            .or_insert(ConnectionInfo {
+                interface: seg.interface,
+                total_bytes_downloaded: 0,
+                total_bytes_uploaded: 0,
+            });
         match seg.direction {
             Direction::Download => {
                 total_bandwidth.total_bytes_downloaded += seg.data_length;

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -4,7 +4,7 @@ use ::std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct ConnectionInfo {
-    pub interface: String,
+    pub interface_name: String,
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
 }
@@ -29,7 +29,7 @@ impl Utilization {
             .connections
             .entry(seg.connection)
             .or_insert(ConnectionInfo {
-                interface: seg.interface,
+                interface_name: seg.interface_name,
                 total_bytes_downloaded: 0,
                 total_bytes_uploaded: 0,
             });

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -12,6 +12,7 @@ use ::std::net::IpAddr;
 
 use packet_builder::payload::PayloadData;
 use packet_builder::*;
+use pnet::datalink::DataLinkReceiver;
 use pnet::packet::Packet;
 use pnet_base::MacAddr;
 
@@ -71,7 +72,7 @@ fn one_packet_of_traffic() {
         443,
         12345,
         b"I am a fake tcp packet",
-    ))])];
+    ))]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -140,7 +141,7 @@ fn bi_directional_traffic() {
             443,
             b"I am a fake tcp download packet",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -209,7 +210,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
             443,
             b"I come from 2.2.2.2",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -278,7 +279,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
             443,
             b"I've come from 1.1.1.1 too!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -347,7 +348,7 @@ fn one_process_with_multiple_connections() {
             443,
             b"Funny that, I'm from 3.3.3.3",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -430,7 +431,7 @@ fn multiple_processes_with_multiple_connections() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -499,7 +500,7 @@ fn multiple_connections_from_remote_address() {
             443,
             b"Me too, but on a different port",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -570,7 +571,7 @@ fn sustained_traffic_from_one_process() {
             443,
             b"Same here, but one second later",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -655,7 +656,7 @@ fn sustained_traffic_from_multiple_processes() {
             443,
             b"I come 3.3.3.3 one second later",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -768,7 +769,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -881,7 +882,7 @@ fn traffic_with_host_names() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1007,7 +1008,7 @@ fn no_resolve_mode() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -1,5 +1,5 @@
 use crate::tests::fakes::{
-    create_fake_dns_client, create_fake_on_winch, get_interface, get_open_sockets, KeyboardEvents,
+    create_fake_dns_client, create_fake_on_winch, get_interfaces, get_open_sockets, KeyboardEvents,
     NetworkFrames, TestBackend,
 };
 
@@ -65,13 +65,13 @@ fn one_packet_of_traffic() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![Some(build_tcp_packet(
+    let network_frames = vec![NetworkFrames::new(vec![Some(build_tcp_packet(
         "10.0.0.2",
         "1.1.1.1",
         443,
         12345,
         b"I am a fake tcp packet",
-    ))]);
+    ))])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -84,7 +84,7 @@ fn one_packet_of_traffic() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -98,7 +98,7 @@ fn one_packet_of_traffic() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -108,7 +108,7 @@ fn one_packet_of_traffic() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -125,7 +125,7 @@ fn bi_directional_traffic() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "1.1.1.1",
@@ -140,7 +140,7 @@ fn bi_directional_traffic() {
             443,
             b"I am a fake tcp download packet",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -153,7 +153,7 @@ fn bi_directional_traffic() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -167,7 +167,7 @@ fn bi_directional_traffic() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -177,7 +177,7 @@ fn bi_directional_traffic() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -194,7 +194,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -209,7 +209,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
             443,
             b"I come from 2.2.2.2",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -224,7 +224,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
     );
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let stdout = Arc::new(Mutex::new(Vec::new()));
     let write_to_stdout = Box::new({
@@ -236,7 +236,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         on_winch,
@@ -246,7 +246,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -263,7 +263,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -278,7 +278,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
             443,
             b"I've come from 1.1.1.1 too!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -291,7 +291,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -305,7 +305,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -315,7 +315,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -332,7 +332,7 @@ fn one_process_with_multiple_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -347,7 +347,7 @@ fn one_process_with_multiple_connections() {
             443,
             b"Funny that, I'm from 3.3.3.3",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -360,7 +360,7 @@ fn one_process_with_multiple_connections() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -374,7 +374,7 @@ fn one_process_with_multiple_connections() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -384,7 +384,7 @@ fn one_process_with_multiple_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -401,7 +401,7 @@ fn multiple_processes_with_multiple_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -430,7 +430,7 @@ fn multiple_processes_with_multiple_connections() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -443,7 +443,7 @@ fn multiple_processes_with_multiple_connections() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -457,7 +457,7 @@ fn multiple_processes_with_multiple_connections() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -467,7 +467,7 @@ fn multiple_processes_with_multiple_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -484,7 +484,7 @@ fn multiple_connections_from_remote_address() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -499,7 +499,7 @@ fn multiple_connections_from_remote_address() {
             443,
             b"Me too, but on a different port",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -512,7 +512,7 @@ fn multiple_connections_from_remote_address() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -526,7 +526,7 @@ fn multiple_connections_from_remote_address() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -536,7 +536,7 @@ fn multiple_connections_from_remote_address() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -554,7 +554,7 @@ fn sustained_traffic_from_one_process() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -570,7 +570,7 @@ fn sustained_traffic_from_one_process() {
             443,
             b"Same here, but one second later",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -583,7 +583,7 @@ fn sustained_traffic_from_one_process() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -597,7 +597,7 @@ fn sustained_traffic_from_one_process() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -607,7 +607,7 @@ fn sustained_traffic_from_one_process() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -625,7 +625,7 @@ fn sustained_traffic_from_multiple_processes() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -655,7 +655,7 @@ fn sustained_traffic_from_multiple_processes() {
             443,
             b"I come 3.3.3.3 one second later",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -668,7 +668,7 @@ fn sustained_traffic_from_multiple_processes() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -682,7 +682,7 @@ fn sustained_traffic_from_multiple_processes() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -692,7 +692,7 @@ fn sustained_traffic_from_multiple_processes() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -710,7 +710,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -768,7 +768,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -781,7 +781,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
@@ -795,7 +795,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -805,7 +805,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -823,7 +823,7 @@ fn traffic_with_host_names() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -881,7 +881,7 @@ fn traffic_with_host_names() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -894,7 +894,7 @@ fn traffic_with_host_names() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -921,7 +921,7 @@ fn traffic_with_host_names() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -931,7 +931,7 @@ fn traffic_with_host_names() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: false,
     };
@@ -949,7 +949,7 @@ fn no_resolve_mode() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -1007,7 +1007,7 @@ fn no_resolve_mode() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1020,7 +1020,7 @@ fn no_resolve_mode() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -1047,7 +1047,7 @@ fn no_resolve_mode() {
     });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1057,7 +1057,7 @@ fn no_resolve_mode() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: true,
         no_resolve: true,
     };

--- a/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
@@ -3,6 +3,6 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 49/51 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 49/51 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 49/51 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 49/51 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
@@ -4,7 +4,7 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "3" up/down Bps: 0/51 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/51 process: "3"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/51 process: "3"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/95 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
@@ -4,8 +4,8 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/39 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 2.2.2.2:54321 (tcp) up/down Bps: 0/39 process: "4"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 2.2.2.2:54321 (tcp) up/down Bps: 0/39 process: "4"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/39 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
@@ -3,6 +3,6 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/91 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/91 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/91 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/91 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
@@ -6,10 +6,10 @@ process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/42 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/53 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/45 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 2.2.2.2:54321 (tcp) up/down Bps: 0/53 process: "4"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/45 process: "5"
-connection: <TIMESTAMP_REMOVED> :443 => 4.4.4.4:1337 (tcp) up/down Bps: 0/42 process: "2"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 2.2.2.2:54321 (tcp) up/down Bps: 0/53 process: "4"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/45 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 4.4.4.4:1337 (tcp) up/down Bps: 0/42 process: "2"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/53 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/45 connections: 1

--- a/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
@@ -4,14 +4,14 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 57/61 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 34/37 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 37/36 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 32/46 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
@@ -3,6 +3,6 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 42/0 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 42/0 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 42/0 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 42/0 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
@@ -4,8 +4,8 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/48 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/48 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/48 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/48 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
@@ -4,14 +4,14 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/39 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/39 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/39 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/39 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/61 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/51 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/61 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/51 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/61 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 0/51 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/61 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/51 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -4,14 +4,14 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 57/61 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 34/37 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 37/36 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 32/46 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
@@ -3,9 +3,9 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/51 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/51 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/51 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/51 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
@@ -4,14 +4,14 @@ expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => one.one.one.one:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => three.three.three.three:1337 (tcp) up/down Bps: 34/37 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 57/61 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => three.three.three.three:1337 (tcp) up/down Bps: 34/37 process: "5"
 remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 57/61 connections: 1
 remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 34/37 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> :443 => one.one.one.one:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> :443 => three.three.three.three:1337 (tcp) up/down Bps: 32/46 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 37/36 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => three.three.three.three:1337 (tcp) up/down Bps: 32/46 process: "5"
 remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 37/36 connections: 1
 remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 32/46 connections: 1
 

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     49Bps/51Bps          :443 => 1.1.1.1:12345 (tcp)                         1                     49Bps/51Bps         
+ 1                                                   1                     49Bps/51Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     49Bps/51Bps         
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps/53Bps           :443 => 2.2.2.2:54321 (tcp)                         4                     0Bps/53Bps          
- 5                                                   1                     0Bps/45Bps           :443 => 3.3.3.3:1337 (tcp)                          5                     0Bps/45Bps          
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
- 2                                                   1                     0Bps/42Bps           :443 => 4.4.4.4:1337 (tcp)                          2                     0Bps/42Bps          
+ 4                                                   1                     0Bps/53Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps          
+ 5                                                   1                     0Bps/45Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
+ 2                                                   1                     0Bps/42Bps           <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -30,10 +30,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
- :443 => 2.2.2.2:54321 (tcp)                         4                     0Bps/53Bps                                  
- :443 => 3.3.3.3:1337 (tcp)                          5                     0Bps/45Bps                                  
- :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps                                  
- :443 => 4.4.4.4:1337 (tcp)                          2                     0Bps/42Bps                                  
+ <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps                                  
+ <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps                                  
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps                                  
+ <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps                                  
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
@@ -30,10 +30,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- :443 => 2.2.2.2:54321 (tcp)               0Bps/53Bps                      2.2.2.2                                   0Bps/53Bps                      
- :443 => 3.3.3.3:1337 (tcp)                0Bps/45Bps                      3.3.3.3                                   0Bps/45Bps                      
- :443 => 1.1.1.1:12345 (tcp)               0Bps/44Bps                      1.1.1.1                                   0Bps/44Bps                      
- :443 => 4.4.4.4:1337 (tcp)                0Bps/42Bps                      4.4.4.4                                   0Bps/42Bps                      
+ <interface_name>:443 => 2.2.2.2:54321 (t  0Bps/53Bps                      2.2.2.2                                   0Bps/53Bps                      
+ <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps/45Bps                      3.3.3.3                                   0Bps/45Bps                      
+ <interface_name>:443 => 1.1.1.1:12345 (t  0Bps/44Bps                      1.1.1.1                                   0Bps/44Bps                      
+ <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps/42Bps                      4.4.4.4                                   0Bps/42Bps                      
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- 4                                         0Bps/53Bps                      :443 => 2.2.2.2:54321 (tcp)               0Bps/53Bps                      
- 5                                         0Bps/45Bps                      :443 => 3.3.3.3:1337 (tcp)                0Bps/45Bps                      
- 1                                         0Bps/44Bps                      :443 => 1.1.1.1:12345 (tcp)               0Bps/44Bps                      
- 2                                         0Bps/42Bps                      :443 => 4.4.4.4:1337 (tcp)                0Bps/42Bps                      
+ 4                                         0Bps/53Bps                      <interface_name>:443 => 2.2.2.2:54321 (t  0Bps/53Bps                      
+ 5                                         0Bps/45Bps                      <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps/45Bps                      
+ 1                                         0Bps/44Bps                      <interface_name>:443 => 1.1.1.1:12345 (t  0Bps/44Bps                      
+ 2                                         0Bps/42Bps                      <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps/42Bps                      
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 3                                                   1                     0Bps/51Bps           :443 => 1.1.1.1:12346 (tcp)                         3                     0Bps/51Bps          
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
+ 3                                                   1                     0Bps/51Bps           <interface_name>:443 => 1.1.1.1:12346 (tcp)         3                     0Bps/51Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
- 4                                                   1                     0Bps/39Bps           :443 => 2.2.2.2:54321 (tcp)                         4                     0Bps/39Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
+ 4                                                   1                     0Bps/39Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/39Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/91Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/91Bps          
+ 1                                                   1                     0Bps/91Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/91Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps/53Bps           :443 => 2.2.2.2:54321 (tcp)                         4                     0Bps/53Bps          
- 5                                                   1                     0Bps/45Bps           :443 => 3.3.3.3:1337 (tcp)                          5                     0Bps/45Bps          
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
- 2                                                   1                     0Bps/42Bps           :443 => 4.4.4.4:1337 (tcp)                          2                     0Bps/42Bps          
+ 4                                                   1                     0Bps/53Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps          
+ 5                                                   1                     0Bps/45Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
+ 2                                                   1                     0Bps/42Bps           <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                     3 3 3 3  3 7 (tcp)                          5                     32    46            
- 1                                                                          7     6                     1 1 1 1  2 45 (tcp)                         1                      7     6            
+ 5                                                                         32    46                                     3 3 3 3  3 7 (tcp)          5                     32    46            
+ 1                                                                          7     6                                     1 1 1 1  2 45 (tcp)         1                      7     6            
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          :443 => 1.1.1.1:12345 (tcp)                         1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          :443 => 3.3.3.3:1337 (tcp)                          5                     34Bps/37Bps         
+ 1                                                   1                     57Bps/61Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps/61Bps         
+ 5                                                   1                     34Bps/37Bps          <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps/37Bps         
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps/0Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     42Bps/0Bps          
+ 1                                                   1                     42Bps/0Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps/0Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                   1                     0Bps/48Bps           :443 => 3.3.3.3:1337 (tcp)                          5                     0Bps/48Bps          
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
+ 5                                                   1                     0Bps/48Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/48Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
- 5                                                   1                     0Bps/39Bps           :443 => 3.3.3.3:1337 (tcp)                          5                     0Bps/39Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
+ 5                                                   1                     0Bps/39Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/39Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                     3 3 3 3  3 7 (tcp)                          5                     32    46            
- 1                                                                          7     6                     1 1 1 1  2 45 (tcp)                         1                      7     6            
+ 5                                                                         32    46                                     3 3 3 3  3 7 (tcp)          5                     32    46            
+ 1                                                                          7     6                                     1 1 1 1  2 45 (tcp)         1                      7     6            
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          :443 => 1.1.1.1:12345 (tcp)                         1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          :443 => 3.3.3.3:1337 (tcp)                          5                     34Bps/37Bps         
+ 1                                                   1                     57Bps/61Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps/61Bps         
+ 5                                                   1                     34Bps/37Bps          <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps/37Bps         
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     0Bps/44Bps          
+ 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                     three.thre  three.three:1337 (tcp)          5                     32    46            
- 1                                                                          7     6                     one.one.on  one:12345 (tcp)                 1                      7     6            
+ 5                                                                         32    46                                     three.thre  three.three:13  5                     32    46            
+ 1                                                                          7     6                                     one.one.on  one:12345 (tcp  1                      7     6            
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          :443 => one.one.one.one:12345 (tcp)                 1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          :443 => three.three.three.three:1337 (tcp)          5                     34Bps/37Bps         
+ 1                                                   1                     57Bps/61Bps          <interface_name>:443 => one.one.one.one:12345 (tcp  1                     57Bps/61Bps         
+ 5                                                   1                     34Bps/37Bps          <interface_name>:443 => three.three.three.three:13  5                     34Bps/37Bps         
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps/0Bps           :443 => 1.1.1.1:12345 (tcp)                         1                     42Bps/0Bps          
+ 1                                                   1                     42Bps/0Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps/0Bps          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -1,6 +1,6 @@
 use crate::tests::fakes::TerminalEvent::*;
 use crate::tests::fakes::{
-    create_fake_dns_client, create_fake_on_winch, get_interface, get_open_sockets, KeyboardEvents,
+    create_fake_dns_client, create_fake_on_winch, get_interfaces, get_open_sockets, KeyboardEvents,
     NetworkFrames, TestBackend,
 };
 
@@ -55,9 +55,9 @@ fn basic_startup() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         None, // sleep
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -70,14 +70,14 @@ fn basic_startup() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -87,7 +87,7 @@ fn basic_startup() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -110,13 +110,13 @@ fn one_packet_of_traffic() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![Some(build_tcp_packet(
+    let network_frames = vec![NetworkFrames::new(vec![Some(build_tcp_packet(
         "10.0.0.2",
         "1.1.1.1",
         443,
         12345,
         b"I am a fake tcp packet",
-    ))]);
+    ))])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -129,14 +129,14 @@ fn one_packet_of_traffic() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -146,7 +146,7 @@ fn one_packet_of_traffic() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -172,7 +172,7 @@ fn bi_directional_traffic() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "1.1.1.1",
@@ -187,7 +187,7 @@ fn bi_directional_traffic() {
             443,
             b"I am a fake tcp download packet",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -200,14 +200,14 @@ fn bi_directional_traffic() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let write_to_stdout = Box::new({ move |_output: String| {} });
     let cleanup = Box::new(|| {});
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -217,7 +217,7 @@ fn bi_directional_traffic() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -243,7 +243,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -258,7 +258,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
             443,
             b"I come from 2.2.2.2",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -273,12 +273,12 @@ fn multiple_packets_of_traffic_from_different_connections() {
     );
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         on_winch,
@@ -288,7 +288,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -314,7 +314,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -329,7 +329,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
             443,
             b"I've come from 1.1.1.1 too!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -342,14 +342,14 @@ fn multiple_packets_of_traffic_from_single_connection() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -359,7 +359,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -385,7 +385,7 @@ fn one_process_with_multiple_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -400,7 +400,7 @@ fn one_process_with_multiple_connections() {
             443,
             b"Funny that, I'm from 3.3.3.3",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -413,14 +413,14 @@ fn one_process_with_multiple_connections() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -430,7 +430,7 @@ fn one_process_with_multiple_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -456,7 +456,7 @@ fn multiple_processes_with_multiple_connections() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -485,7 +485,7 @@ fn multiple_processes_with_multiple_connections() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -498,14 +498,14 @@ fn multiple_processes_with_multiple_connections() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -515,7 +515,7 @@ fn multiple_processes_with_multiple_connections() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -541,7 +541,7 @@ fn multiple_connections_from_remote_address() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -556,7 +556,7 @@ fn multiple_connections_from_remote_address() {
             443,
             b"Me too, but on a different port",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -569,14 +569,14 @@ fn multiple_connections_from_remote_address() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -586,7 +586,7 @@ fn multiple_connections_from_remote_address() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -613,7 +613,7 @@ fn sustained_traffic_from_one_process() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -629,7 +629,7 @@ fn sustained_traffic_from_one_process() {
             443,
             b"Same here, but one second later",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -642,14 +642,14 @@ fn sustained_traffic_from_one_process() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -659,7 +659,7 @@ fn sustained_traffic_from_one_process() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -686,7 +686,7 @@ fn sustained_traffic_from_multiple_processes() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -716,7 +716,7 @@ fn sustained_traffic_from_multiple_processes() {
             443,
             b"I come 3.3.3.3 one second later",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -729,14 +729,14 @@ fn sustained_traffic_from_multiple_processes() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -746,7 +746,7 @@ fn sustained_traffic_from_multiple_processes() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -773,7 +773,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -831,7 +831,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -844,14 +844,14 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -861,7 +861,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -888,7 +888,7 @@ fn traffic_with_host_names() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -946,7 +946,7 @@ fn traffic_with_host_names() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -959,7 +959,7 @@ fn traffic_with_host_names() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -979,7 +979,7 @@ fn traffic_with_host_names() {
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -989,7 +989,7 @@ fn traffic_with_host_names() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1016,7 +1016,7 @@ fn no_resolve_mode() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "10.0.0.2",
             "3.3.3.3",
@@ -1074,7 +1074,7 @@ fn no_resolve_mode() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1087,7 +1087,7 @@ fn no_resolve_mode() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -1107,7 +1107,7 @@ fn no_resolve_mode() {
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1117,7 +1117,7 @@ fn no_resolve_mode() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: true,
     };
@@ -1143,13 +1143,13 @@ fn traffic_with_winch_event() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![Some(build_tcp_packet(
+    let network_frames = vec![NetworkFrames::new(vec![Some(build_tcp_packet(
         "10.0.0.2",
         "1.1.1.1",
         443,
         12345,
         b"I am a fake tcp packet",
-    ))]);
+    ))])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1162,14 +1162,14 @@ fn traffic_with_winch_event() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(true);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1179,7 +1179,7 @@ fn traffic_with_winch_event() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1206,7 +1206,7 @@ fn layout_full_width_under_30_height() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -1235,7 +1235,7 @@ fn layout_full_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(29));
@@ -1248,14 +1248,14 @@ fn layout_full_width_under_30_height() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1265,7 +1265,7 @@ fn layout_full_width_under_30_height() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1291,7 +1291,7 @@ fn layout_under_150_width_full_height() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -1320,7 +1320,7 @@ fn layout_under_150_width_full_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(149));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1333,14 +1333,14 @@ fn layout_under_150_width_full_height() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1350,7 +1350,7 @@ fn layout_under_150_width_full_height() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1376,7 +1376,7 @@ fn layout_under_150_width_under_30_height() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -1405,7 +1405,7 @@ fn layout_under_150_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(149));
     let terminal_height = Arc::new(Mutex::new(29));
@@ -1418,14 +1418,14 @@ fn layout_under_150_width_under_30_height() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1435,7 +1435,7 @@ fn layout_under_150_width_under_30_height() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1461,7 +1461,7 @@ fn layout_under_120_width_full_height() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -1490,7 +1490,7 @@ fn layout_under_120_width_full_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(119));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1503,14 +1503,14 @@ fn layout_under_120_width_full_height() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1520,7 +1520,7 @@ fn layout_under_120_width_full_height() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };
@@ -1546,7 +1546,7 @@ fn layout_under_120_width_under_30_height() {
         None, // sleep
         Some(Event::Key(Key::Ctrl('c'))),
     ]));
-    let network_frames = NetworkFrames::new(vec![
+    let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
             "1.1.1.1",
             "10.0.0.2",
@@ -1575,7 +1575,7 @@ fn layout_under_120_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ]);
+    ])];
 
     let terminal_width = Arc::new(Mutex::new(119));
     let terminal_height = Arc::new(Mutex::new(29));
@@ -1588,14 +1588,14 @@ fn layout_under_120_width_under_30_height() {
         terminal_width,
         terminal_height,
     );
-    let network_interface = get_interface();
+    let network_interfaces = get_interfaces();
     let dns_client = create_fake_dns_client(HashMap::new());
     let on_winch = create_fake_on_winch(false);
     let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new({ move |_output: String| {} });
 
     let os_input = OsInputOutput {
-        network_interface,
+        network_interfaces,
         network_frames,
         get_open_sockets,
         keyboard_events,
@@ -1605,7 +1605,7 @@ fn layout_under_120_width_under_30_height() {
         write_to_stdout,
     };
     let opts = Opt {
-        interface: String::from("interface_name"),
+        interface: Some(String::from("interface_name")),
         raw: false,
         no_resolve: false,
     };

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -13,6 +13,7 @@ use ::std::net::IpAddr;
 
 use packet_builder::payload::PayloadData;
 use packet_builder::*;
+use pnet::datalink::DataLinkReceiver;
 use pnet::packet::Packet;
 use pnet_base::MacAddr;
 
@@ -57,7 +58,7 @@ fn basic_startup() {
     ]));
     let network_frames = vec![NetworkFrames::new(vec![
         None, // sleep
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -116,7 +117,7 @@ fn one_packet_of_traffic() {
         443,
         12345,
         b"I am a fake tcp packet",
-    ))])];
+    ))]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -187,7 +188,7 @@ fn bi_directional_traffic() {
             443,
             b"I am a fake tcp download packet",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -258,7 +259,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
             443,
             b"I come from 2.2.2.2",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -329,7 +330,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
             443,
             b"I've come from 1.1.1.1 too!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -400,7 +401,7 @@ fn one_process_with_multiple_connections() {
             443,
             b"Funny that, I'm from 3.3.3.3",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -485,7 +486,7 @@ fn multiple_processes_with_multiple_connections() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -556,7 +557,7 @@ fn multiple_connections_from_remote_address() {
             443,
             b"Me too, but on a different port",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -629,7 +630,7 @@ fn sustained_traffic_from_one_process() {
             443,
             b"Same here, but one second later",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -716,7 +717,7 @@ fn sustained_traffic_from_multiple_processes() {
             443,
             b"I come 3.3.3.3 one second later",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -831,7 +832,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -946,7 +947,7 @@ fn traffic_with_host_names() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1074,7 +1075,7 @@ fn no_resolve_mode() {
             12345,
             b"10.0.0.2 forever!",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1149,7 +1150,7 @@ fn traffic_with_winch_event() {
         443,
         12345,
         b"I am a fake tcp packet",
-    ))])];
+    ))]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1235,7 +1236,7 @@ fn layout_full_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(190));
     let terminal_height = Arc::new(Mutex::new(29));
@@ -1320,7 +1321,7 @@ fn layout_under_150_width_full_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(149));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1405,7 +1406,7 @@ fn layout_under_150_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(149));
     let terminal_height = Arc::new(Mutex::new(29));
@@ -1490,7 +1491,7 @@ fn layout_under_120_width_full_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(119));
     let terminal_height = Arc::new(Mutex::new(50));
@@ -1575,7 +1576,7 @@ fn layout_under_120_width_under_30_height() {
             443,
             b"I'm partial to 4.4.4.4",
         )),
-    ])];
+    ]) as Box<dyn DataLinkReceiver>];
 
     let terminal_width = Arc::new(Mutex::new(119));
     let terminal_height = Arc::new(Mutex::new(29));

--- a/src/tests/fakes/fake_input.rs
+++ b/src/tests/fakes/fake_input.rs
@@ -50,7 +50,7 @@ pub struct NetworkFrames {
 }
 
 impl NetworkFrames {
-    pub fn new(packets: Vec<Option<Vec<u8>>>) -> Box<Self> {
+    pub fn new(packets: Vec<Option<Vec<u8>>>) -> Box<dyn DataLinkReceiver> {
         Box::new(NetworkFrames {
             packets,
             current_index: 0,
@@ -135,14 +135,14 @@ pub fn get_open_sockets() -> HashMap<Connection, String> {
     open_sockets
 }
 
-pub fn get_interface() -> NetworkInterface {
-    NetworkInterface {
+pub fn get_interfaces() -> Vec<NetworkInterface> {
+    vec![NetworkInterface {
         name: String::from("interface_name"),
         index: 42,
         mac: None,
         ips: vec![IpNetwork::V4("10.0.0.2".parse().unwrap())],
         flags: 42,
-    }
+    }]
 }
 
 pub fn create_fake_on_winch(should_send_winch_event: bool) -> Box<OnSigWinch> {

--- a/src/tests/fakes/fake_input.rs
+++ b/src/tests/fakes/fake_input.rs
@@ -50,7 +50,7 @@ pub struct NetworkFrames {
 }
 
 impl NetworkFrames {
-    pub fn new(packets: Vec<Option<Vec<u8>>>) -> Box<dyn DataLinkReceiver> {
+    pub fn new(packets: Vec<Option<Vec<u8>>>) -> Box<Self> {
         Box::new(NetworkFrames {
             packets,
             current_index: 0,


### PR DESCRIPTION
The parameter "-i" is now optional and we listen on all interfaces by default.
The interface is shown in the connections table.

I've changed the read timeout for the datalink channel from 1 ns to 2 ms because I realized (before the changes) that we were using quite some CPU there. In my computer it went from taking consistently over 10% of one CPU to ~2%. I think it should be enough to handle the traffic and to keep the application responsive to the "quit" key. Let me know if you find it appropriate!

Closes #16 