### PR TITLE
fix(packages): Fix trust-dns-resolver version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,7 +1647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "what"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "what"
 description = "Display current network utilization by process, connection and remote IP/hostname"
-version = "0.4.0"
+version = "0.4.1"
 homepage = "https://github.com/imsnif/what"
 repository = "https://github.com/imsnif/what"
 readme = "README.md"
@@ -27,8 +27,8 @@ failure = "0.1.6"
 chrono = "0.4"
 regex = "1.3.1"
 lazy_static = "1.4.0"
-tokio = { version = "^0.2", features = ["rt-core", "sync"] }
-trust-dns-resolver = "0.18.0-alpha.2"
+tokio = { version = "0.2", features = ["rt-core", "sync"] }
+trust-dns-resolver = "=0.18.0-alpha.2"
 async-trait = "0.1.21"
 
 [target.'cfg(target_os="linux")'.dependencies]


### PR DESCRIPTION
So, for the moment I've fixed the version of trust-dns-resolver to the one we were using. There are some breaking changes so I think it would be wise for us to wait until the next stable release before upgrading.

@imsnif this will require publishing to crates.io. I should have used the "=" syntax given that we were relying on an alpha version, my apologies!

Fixes #24 